### PR TITLE
Variable.choice_queryset should look up the target instance from the …

### DIFF
--- a/lib/tri/query/__init__.py
+++ b/lib/tri/query/__init__.py
@@ -166,7 +166,7 @@ class Variable(Frozen, VariableBase):
             if variable.attr is None:
                 return Q()
             try:
-                instance = variable.model.objects.get(**{variable.value_to_q_lookup: value_string_or_f})
+                instance = kwargs['choices'].get(**{variable.value_to_q_lookup: value_string_or_f})
             except ObjectDoesNotExist:
                 return None
             return Q(**{variable.attr + '__pk': instance.pk})

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -211,7 +211,7 @@ def test_choice_queryset():
     assert not form.is_valid()
     form = query2.form(Struct(method='POST', POST=Data({'foo': str(random_valid_obj.pk)})))
     assert form.is_valid()
-    assert set(form.fields_by_name['foo'].choices) == {None} | set(Foo.objects.all())
+    assert set(form.fields_by_name['foo'].choices) == set(Foo.objects.all())
 
     # test query
     # noinspection PyTypeChecker


### PR DESCRIPTION
…given queryset, not for all objects

A trivial use case I had was from mammon where a user has a list of categories, and another user can have another category with the same name. tri.query incorrectly assumed that it could just look up based on the name for all categories.